### PR TITLE
Add favicon to head partial

### DIFF
--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="stylesheet" href="{{site.url}}assets/css/site.css?v={{site.cssVersion}}" />
+    <link rel="shortcut icon" href="{{site.url}}favicon.ico" type="image/x-icon" />
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
Some browsers automatically find and cache this so to verify it works, change the href that is pointed to e.g. `{{site.url}}assets/img/mr-streetwise.jpg`